### PR TITLE
feat: Add skeleton for Leagues page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -15,6 +15,11 @@
             v-if="loggedIn"
             variant="text"
         >Game Types</v-btn>
+        <v-btn
+            to="/ui/leagues"
+            v-if="loggedIn"
+            variant="text"
+        >Leagues</v-btn>
         <gameround-menu-item v-if="loggedIn" />
         <v-btn
             to="/ui/user"
@@ -41,6 +46,11 @@
             v-if="loggedIn"
             to="/ui/admin/game-types"
             :title="t('gameTypes.title')"
+        />
+        <v-list-item
+            v-if="loggedIn"
+            to="/ui/leagues"
+            title="Leagues"
         />
         <v-list-item
             v-if="loggedIn"

--- a/frontend/src/gametypes/ListLeagues.vue
+++ b/frontend/src/gametypes/ListLeagues.vue
@@ -1,0 +1,15 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <h2>Leagues</h2>
+        <p>This is the page for managing leagues. It is currently under construction.</p>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts" setup>
+// This is a placeholder component.
+// The logic for fetching and displaying leagues will be added later.
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -34,6 +34,11 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/gametypes/GameroundsList.vue')
   },
   {
+    path: '/ui/leagues',
+    name: 'Leagues',
+    component: () => import('@/gametypes/ListLeagues.vue')
+  },
+  {
     path: '/ui/game-rounds/new',
     name: 'NewGameRound',
     component: () => import('@/gametypes/GameroundEdit.vue')


### PR DESCRIPTION
This commit introduces the initial scaffolding for a new "Leagues" feature in the frontend application.

It includes:
- A new placeholder Vue component `ListLeagues.vue`.
- A new route `/ui/leagues` in the Vue router.
- Navigation links to the new page in the main app bar and mobile navigation drawer.

This provides the basic structure for the new feature, allowing for further development of the league management functionality.